### PR TITLE
fix : preventing modifying the widget tree while it is still building

### DIFF
--- a/lib/presentation/widgets/all_pokemon_widget.dart
+++ b/lib/presentation/widgets/all_pokemon_widget.dart
@@ -18,6 +18,7 @@ class _AllPokemonWidgetState extends ConsumerState<AllPokemonWidget> {
       PagingController<int, PokemonDetailEntity>(firstPageKey: 0);
 
   int pageLimit = 20;
+  final initialPage = 0;
 
   _onTapPokemon(PokemonDetailEntity pokemonDetail) {
     Navigator.of(context)
@@ -26,7 +27,7 @@ class _AllPokemonWidgetState extends ConsumerState<AllPokemonWidget> {
 
   @override
   void initState() {
-    init();
+    Future.delayed(const Duration(milliseconds: 100),()=> init());
     super.initState();
   }
 
@@ -52,6 +53,8 @@ class _AllPokemonWidgetState extends ConsumerState<AllPokemonWidget> {
           ref.read(pokemonListProvider.notifier).state;
       if (cachedPokemons.isNotEmpty) {
         _pagingController.itemList = cachedPokemons;
+      } else {
+        await _fetchPage(initialPage);
       }
 
       _pagingController.addPageRequestListener((pageKey) async {


### PR DESCRIPTION
Issue:
The root cause for the issue was that we were modifying the widget tree while it was still building. 

Fix:
The framework suggested adding a delay with 'Future'


![Screenshot 2023-04-30 at 12 25 50 PM](https://user-images.githubusercontent.com/16346765/235340059-e6cd35f0-5c11-4953-9340-480b44fd5708.png)

This Fixes #1 
